### PR TITLE
Dolfinx 0.11.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: fenics-reinforcement
 channels:
   - conda-forge
 dependencies:
-  - fenics-dolfinx
+  - fenics-dolfinx=0.11.0
   - pint
   - pytest
   - python-gmsh

--- a/examples/3_point_bending.py
+++ b/examples/3_point_bending.py
@@ -1,6 +1,8 @@
 from reinforcement.mesh import create_concrete_slab, read_xdmf
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
+import dolfinx.fem.petsc
+import dolfinx.nls.petsc
 import ufl
 import numpy as np
 from petsc4py import PETSc
@@ -62,7 +64,7 @@ create_concrete_slab(
 
 concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
 
-P1 = dfx.fem.VectorFunctionSpace(concrete_mesh, ("CG", 1))
+P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
 rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
 
@@ -121,6 +123,10 @@ def left(x):
 def right(x):
     return np.logical_and(np.isclose(x[0], length - margin), np.isclose(x[2], 0.0))
 
+
+concrete_mesh.topology.create_connectivity(
+    concrete_mesh.topology.dim - 2, concrete_mesh.topology.dim
+)
 
 # left side
 boundary_entities_left = dfx.mesh.locate_entities_boundary(

--- a/examples/3_point_bending.py
+++ b/examples/3_point_bending.py
@@ -1,4 +1,4 @@
-from reinforcement.mesh import create_concrete_slab, read_xdmf
+from reinforcement.mesh import create_concrete_slab, read_msh
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
 import dolfinx.fem.petsc
@@ -62,11 +62,11 @@ create_concrete_slab(
     point1, point2, nx, ny, margin, h, msh_filename, xdmf_filenames, z=[z_rebar]
 )
 
-concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
+concrete_mesh, rebar_mesh, vertex_map = read_msh(msh_filename)
 
 P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
-rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
+rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel, vertex_map)
 
 
 def eps(v):

--- a/src/reinforcement/__init__.py
+++ b/src/reinforcement/__init__.py
@@ -1,2 +1,2 @@
 from .rebar import RebarInterface, ElasticTrussRebar
-from .mesh import create_concrete_slab, read_xdmf
+from .mesh import create_concrete_slab, read_xdmf, read_msh

--- a/src/reinforcement/__init__.py
+++ b/src/reinforcement/__init__.py
@@ -1,2 +1,3 @@
 from .rebar import RebarInterface, ElasticTrussRebar
 from .mesh import create_concrete_slab, read_xdmf, read_msh
+from .maps import SubSpaceMap, build_vertex_subspace_map

--- a/src/reinforcement/maps.py
+++ b/src/reinforcement/maps.py
@@ -1,0 +1,133 @@
+"""Dof-index mapping between a mesh and a lower-dimensional submesh of it.
+
+Adapted from the SubSpaceMap in BAMresearch/fenics-constitutive
+(src/fenics_constitutive/solver/maps.py). That implementation maps between a
+parent mesh and a same-dimension (co-dimension 0) submesh, with the
+correspondence built from per-cell dofmap entries -- e.g. splitting a
+material subdomain out of a larger mesh. Here the submesh has a *lower*
+topological dimension than its parent (reinforcement lines embedded in a 3D
+concrete mesh), so the correspondence instead comes directly from the vertex
+map returned by dolfinx.mesh.create_submesh, which is exact (no
+floating-point coordinate matching needed).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import dolfinx as dfx
+import numpy as np
+
+__all__ = ["SubSpaceMap", "build_vertex_subspace_map"]
+
+
+@dataclass
+class SubSpaceMap:
+    """
+    Maps dofs between a function space on a submesh and a function space on
+    its parent mesh.
+
+    Args:
+        parent: Parent-space dof indices (scalar/unblocked numbering).
+        sub: Sub-space dof indices (scalar/unblocked numbering),
+            corresponding entry-by-entry to `parent`.
+
+    """
+
+    parent: np.ndarray
+    sub: np.ndarray
+
+    def map_to_parent(self, sub: dfx.fem.Function, parent: dfx.fem.Function) -> None:
+        """
+        Copy values from a Function on the submesh into a Function on the
+        parent mesh.
+
+        Args:
+            sub: The function on the submesh.
+            parent: The function on the parent mesh.
+        """
+        assert sub.ufl_shape == parent.ufl_shape, "Shapes do not match"
+        bs = parent.function_space.dofmap.index_map_bs
+        parent_array = parent.x.array.reshape(-1, bs)
+        sub_array = sub.x.array.reshape(-1, bs)
+        parent_array[self.parent] = sub_array[self.sub]
+        parent.x.scatter_forward()
+
+    def map_to_sub(self, parent: dfx.fem.Function, sub: dfx.fem.Function) -> None:
+        """
+        Copy values from a Function on the parent mesh into a Function on
+        the submesh.
+
+        Args:
+            parent: The function on the parent mesh.
+            sub: The function on the submesh.
+        """
+        assert sub.ufl_shape == parent.ufl_shape, "Shapes do not match"
+        bs = parent.function_space.dofmap.index_map_bs
+        parent_array = parent.x.array.reshape(-1, bs)
+        sub_array = sub.x.array.reshape(-1, bs)
+        sub_array[self.sub] = parent_array[self.parent]
+        sub.x.scatter_forward()
+
+
+def build_vertex_subspace_map(
+    vertex_map: np.ndarray,
+    parent_space: dfx.fem.FunctionSpace,
+    sub_space: dfx.fem.FunctionSpace,
+) -> SubSpaceMap:
+    """
+    Build a SubSpaceMap from the vertex map returned by
+    dolfinx.mesh.create_submesh (submesh vertex index -> parent mesh vertex
+    index).
+
+    Both `parent_space` and `sub_space` must be first-order (vertex-based)
+    continuous Lagrange spaces, built on the parent mesh and the submesh
+    respectively. Dof indices are resolved per vertex via
+    dolfinx.fem.locate_dofs_topological rather than assumed to equal the
+    vertex index: dolfinx may internally reorder dofs relative to the
+    mesh's own vertex numbering (e.g. for cache locality), so that
+    equivalence does not hold in general, even though it may appear to for
+    small/simple meshes.
+
+    Args:
+        vertex_map: As returned by dolfinx.mesh.create_submesh (3rd return
+            value): submesh vertex index -> parent mesh vertex index.
+        parent_space: P1 (vector) Lagrange space on the parent mesh.
+        sub_space: P1 (vector) Lagrange space on the submesh.
+
+    Returns:
+        The SubSpaceMap between sub_space and parent_space.
+
+    """
+    parent_mesh = parent_space.mesh
+    sub_mesh = sub_space.mesh
+    parent_mesh.topology.create_connectivity(0, parent_mesh.topology.dim)
+    sub_mesh.topology.create_connectivity(0, sub_mesh.topology.dim)
+
+    num_sub_vertices = len(vertex_map)
+    parent = np.empty(num_sub_vertices, dtype=np.int32)
+    sub = np.empty(num_sub_vertices, dtype=np.int32)
+    for sub_vertex, parent_vertex in enumerate(vertex_map):
+        parent_dof = dfx.fem.locate_dofs_topological(
+            parent_space, 0, np.array([parent_vertex], dtype=np.int32)
+        )
+        sub_dof = dfx.fem.locate_dofs_topological(
+            sub_space, 0, np.array([sub_vertex], dtype=np.int32)
+        )
+        assert len(parent_dof) == 1 and len(sub_dof) == 1, (
+            f"expected exactly 1 dof per vertex, found {len(parent_dof)} (parent) "
+            f"and {len(sub_dof)} (sub) for vertex {sub_vertex}"
+        )
+        parent[sub_vertex] = parent_dof[0]
+        sub[sub_vertex] = sub_dof[0]
+
+    parent_coords = parent_space.tabulate_dof_coordinates()[parent]
+    sub_coords = sub_space.tabulate_dof_coordinates()[sub]
+    if not np.allclose(parent_coords, sub_coords):
+        raise ValueError(
+            "resolved parent/sub dofs do not have matching coordinates; "
+            "both spaces must be first-order Lagrange spaces built directly "
+            "on the parent mesh and the submesh."
+        )
+
+    return SubSpaceMap(parent=parent, sub=sub)

--- a/src/reinforcement/mesh.py
+++ b/src/reinforcement/mesh.py
@@ -304,14 +304,19 @@ def read_xdmf(xdmf_files : list[str]) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh]:
     """
     Function that reads xdmf_files to use them in FEniCSx
 
+    Note:
+        rebar_mesh is read independently of concrete_mesh here, so there is
+        no vertex map between them; it cannot be used with
+        RebarInterface/ElasticTrussRebar, which require one (see read_msh).
+
     Args:
         xdmf_files:
             Names (str) of the xdmf_files, [concrete, reinforcement] - in this order.
 
     Returns:
-        concrete_mesh: 
+        concrete_mesh:
             The concrete mesh (hexa elements).
-        rebar_mesh: 
+        rebar_mesh:
             The reinforcement mesh (line elements).
 
     """
@@ -323,12 +328,15 @@ def read_xdmf(xdmf_files : list[str]) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh]:
     return concrete_mesh, rebar_mesh
 
 
-def read_msh(msh_filename: str, tol: float = 1e-6) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh]:
+def read_msh(
+    msh_filename: str, tol: float = 1e-6
+) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh, np.ndarray]:
     """
-    Reads a msh file directly (as an alternative to read_xdmf), returning the
-    reinforcement mesh as a true submesh of the concrete mesh's edges. Because
-    both meshes are derived from the same concrete_mesh partition, they are
-    guaranteed to live on the same MPI rank when used in parallel.
+    Reads a msh file directly, returning the reinforcement mesh as a true
+    submesh of the concrete mesh's edges, along with the vertex map required
+    by RebarInterface/ElasticTrussRebar. Because both meshes are derived from
+    the same concrete_mesh partition, they are guaranteed to live on the same
+    MPI rank when used in parallel.
 
     The concrete mesh is built via meshio + dolfinx.mesh.create_mesh rather
     than dolfinx.io.gmsh.read_from_msh/model_to_mesh, which crashes whenever a
@@ -350,6 +358,11 @@ def read_msh(msh_filename: str, tol: float = 1e-6) -> tuple[dfx.mesh.Mesh, dfx.m
             The concrete mesh (hexahedron elements).
         rebar_mesh:
             The reinforcement mesh, as a submesh of concrete_mesh's edges.
+        vertex_map:
+            As returned by dolfinx.mesh.create_submesh: rebar_mesh vertex
+            index -> concrete_mesh vertex index. Pass this to
+            ElasticTrussRebar (as `vertex_map`) for exact, tolerance-free dof
+            assignment; see reinforcement.maps.build_vertex_subspace_map.
 
     """
     msh = meshio.read(msh_filename)
@@ -389,5 +402,8 @@ def read_msh(msh_filename: str, tol: float = 1e-6) -> tuple[dfx.mesh.Mesh, dfx.m
         )
         rebar_edges[i] = match[0]
 
-    rebar_mesh, _, _, _ = dfx.mesh.create_submesh(concrete_mesh, 1, rebar_edges)
-    return concrete_mesh, rebar_mesh
+    # create_submesh's 3rd return value (topological vertex map) is an
+    # EntityMap object, not a plain array; the 4th (geometry node map) is
+    # already a plain ndarray and coincides with it for affine P1 meshes.
+    rebar_mesh, _, _, vertex_map = dfx.mesh.create_submesh(concrete_mesh, 1, rebar_edges)
+    return concrete_mesh, rebar_mesh, vertex_map

--- a/src/reinforcement/mesh.py
+++ b/src/reinforcement/mesh.py
@@ -2,10 +2,12 @@
 
 import math
 
+import basix.ufl
 import dolfinx as dfx
 import gmsh
 import meshio
 import numpy as np
+import ufl
 from mpi4py import MPI
 from numpy.typing import ArrayLike
 
@@ -318,4 +320,74 @@ def read_xdmf(xdmf_files : list[str]) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh]:
 
     with dfx.io.XDMFFile(MPI.COMM_WORLD, xdmf_files[1], "r") as xdmf:
         rebar_mesh = xdmf.read_mesh(name="Grid")
+    return concrete_mesh, rebar_mesh
+
+
+def read_msh(msh_filename: str, tol: float = 1e-6) -> tuple[dfx.mesh.Mesh, dfx.mesh.Mesh]:
+    """
+    Reads a msh file directly (as an alternative to read_xdmf), returning the
+    reinforcement mesh as a true submesh of the concrete mesh's edges. Because
+    both meshes are derived from the same concrete_mesh partition, they are
+    guaranteed to live on the same MPI rank when used in parallel.
+
+    The concrete mesh is built via meshio + dolfinx.mesh.create_mesh rather
+    than dolfinx.io.gmsh.read_from_msh/model_to_mesh, which crashes whenever a
+    dimension-1 physical group (the reinforcement lines) coexists with the
+    dimension-3 physical group (the concrete volume) in the same gmsh model
+    (reproduced on dolfinx 0.9.0 and 0.11.0, comm size 1 and under mpiexec).
+    The reinforcement lines' physical group is instead read via meshio, and
+    matched by coordinates against the concrete mesh's own edges.
+
+    Args:
+        msh_filename:
+            Name of the msh file (as created by create_concrete_slab).
+        tol:
+            Absolute coordinate tolerance used to match reinforcement line
+            endpoints to concrete mesh edges.
+
+    Returns:
+        concrete_mesh:
+            The concrete mesh (hexahedron elements).
+        rebar_mesh:
+            The reinforcement mesh, as a submesh of concrete_mesh's edges.
+
+    """
+    msh = meshio.read(msh_filename)
+
+    hex_cells = msh.get_cells_type("hexahedron")
+    # meshio preserves gmsh's node ordering, which differs from dolfinx's own
+    # internal ordering for hexahedra; permute before handing cells to dolfinx
+    # (dolfinx.io.gmsh.model_to_mesh does the same via _cpp.io.perm_gmsh).
+    perm = dfx.io.gmsh.cell_perm_array(dfx.mesh.CellType.hexahedron, hex_cells.shape[1])
+    hex_cells = hex_cells[:, perm]
+    hex_element = basix.ufl.element("Lagrange", "hexahedron", 1, shape=(3,))
+    concrete_mesh = dfx.mesh.create_mesh(
+        MPI.COMM_WORLD, hex_cells, ufl.Mesh(hex_element), msh.points
+    )
+
+    line_cells = msh.get_cells_type("line")
+    rebar_endpoints = msh.points[line_cells]
+
+    tdim = concrete_mesh.topology.dim
+    concrete_mesh.topology.create_connectivity(1, 0)
+    concrete_mesh.topology.create_connectivity(1, tdim)
+    edge_to_vertex = concrete_mesh.topology.connectivity(1, 0)
+    num_edges = concrete_mesh.topology.index_map(1).size_local
+    edge_coords = concrete_mesh.geometry.x[
+        np.array([edge_to_vertex.links(e) for e in range(num_edges)])
+    ]
+
+    rebar_edges = np.empty(len(rebar_endpoints), dtype=np.int32)
+    for i, endpoints in enumerate(rebar_endpoints):
+        forward = np.all(np.isclose(edge_coords, endpoints[None, :, :], atol=tol), axis=(1, 2))
+        backward = np.all(
+            np.isclose(edge_coords, endpoints[None, ::-1, :], atol=tol), axis=(1, 2)
+        )
+        match = np.flatnonzero(forward | backward)
+        assert len(match) == 1, (
+            f"expected exactly 1 matching edge for rebar segment {i}, found {len(match)}"
+        )
+        rebar_edges[i] = match[0]
+
+    rebar_mesh, _, _, _ = dfx.mesh.create_submesh(concrete_mesh, 1, rebar_edges)
     return concrete_mesh, rebar_mesh

--- a/src/reinforcement/mesh.py
+++ b/src/reinforcement/mesh.py
@@ -1,23 +1,20 @@
 # This file covers all functions related to the mesh generation in gmsh and its conversion into separated xdmf files, which can then be used in dolfinx.
 
-import gmsh
-import numpy as np
-import meshio
+import math
+
 import dolfinx as dfx
+import gmsh
+import meshio
+import numpy as np
 from mpi4py import MPI
 from numpy.typing import ArrayLike
-import math
-from itertools import product
-from typing import Tuple,List
 
 
 def _num_elems(min_amount_elems, reinf_elems):
     """
     Corrects number of concrete elements (defined by s) in order to fit the coice of n_x and n_y.
     """
-    if reinf_elems == 0:
-        return min_amount_elems
-    elif min_amount_elems % reinf_elems == 0:
+    if reinf_elems == 0 or min_amount_elems % reinf_elems == 0:
         return min_amount_elems
     else:
         return int(np.ceil(min_amount_elems / reinf_elems)) * reinf_elems

--- a/src/reinforcement/rebar.py
+++ b/src/reinforcement/rebar.py
@@ -4,19 +4,30 @@ import dolfinx as dfx
 import numpy as np
 from petsc4py import PETSc
 
+from .maps import build_vertex_subspace_map
+
 
 class RebarInterface(ABC):
     """
     An interface for trusses. Contains methods to assign dofs.
     """
-    def __init__(self, concrete_mesh : dfx.mesh.Mesh, rebar_mesh : dfx.mesh.Mesh, function_space : dfx.fem.FunctionSpace, parameters: dict):
+    def __init__(
+        self,
+        concrete_mesh : dfx.mesh.Mesh,
+        rebar_mesh : dfx.mesh.Mesh,
+        function_space : dfx.fem.FunctionSpace,
+        parameters: dict,
+        vertex_map: np.ndarray,
+    ):
         """Initialize rebar class
 
         Args:
             concrete_mesh: The 3D mesh of the concrete structure.
-            rebar_mesh: The line mesh of the steel rebar.
+            rebar_mesh: The line mesh of the steel rebar, built as a submesh
+                of concrete_mesh's edges (see reinforcement.mesh.read_msh).
             function_space: The function space object of the concrete structure.
             parameters: A dictinary containing all needed parameters of the steel. Contains: 'A', 'E', 'rho'.
+            vertex_map: rebar_mesh's vertex map, as returned by read_msh.
 
         """
         self.concrete_mesh = concrete_mesh
@@ -24,51 +35,24 @@ class RebarInterface(ABC):
         self.function_space = function_space
         self.parameters = parameters
         self.dof_array = np.array([], dtype=np.int32)
-        self._assign_dofs()
+        self._assign_dofs(vertex_map)
 
-    def _assign_dofs(self, tol=1e-6):
-        # first all reinforcement dofs and their coordinates are found and saved in geometry_entities and points respectively
+    def _assign_dofs(self, vertex_map: np.ndarray):
+        rebar_function_space = dfx.fem.functionspace(self.rebar_mesh, ("Lagrange", 1, (3,)))
+        space_map = build_vertex_subspace_map(vertex_map, self.function_space, rebar_function_space)
+
         fdim = self.rebar_mesh.topology.dim
         self.rebar_mesh.topology.create_connectivity(fdim, 0)
+        cell_to_vertex = self.rebar_mesh.topology.connectivity(fdim, 0)
         num_lines_local = self.rebar_mesh.topology.index_map(fdim).size_local
-        geometry_entities = dfx.cpp.mesh.entities_to_geometry(
-            self.rebar_mesh._cpp_object,
-            fdim,
-            np.arange(num_lines_local, dtype=np.int32),
-            False,
-        )
+
+        block_size = self.function_space.dofmap.index_map_bs
         dofs = []
-        for line in geometry_entities:
-            start = self.rebar_mesh.geometry.x[line][0]
-            end = self.rebar_mesh.geometry.x[line][1]
-
-            dofs_start = self._locate_concrete_dofs(start, tol)
-            dofs_end = self._locate_concrete_dofs(end, tol)
-
-            dofs.extend(dofs_start)
-            dofs.extend(dofs_end)
+        for cell in range(num_lines_local):
+            for rebar_vertex in cell_to_vertex.links(cell):
+                concrete_dof = space_map.parent[rebar_vertex]
+                dofs.extend(block_size * concrete_dof + np.arange(block_size))
         self.dof_array = np.array(dofs, dtype=np.int32).reshape(-1, 3)
-
-    def _locate_concrete_dofs(self, point, tol):
-        x, y, z = point
-
-        def rebar_nodes(var):
-            return np.logical_and(
-                np.logical_and(np.abs(var[1] - y) < tol, np.abs(var[0] - x) < tol),
-                np.abs(var[2] - z) < tol,
-            )
-
-        dofs_toappend = dfx.fem.locate_dofs_geometrical(
-            self.function_space, rebar_nodes
-        )
-        try:
-            assert len(dofs_toappend) == 1
-        except AssertionError:
-            raise Exception(
-                f"{len(dofs_toappend)} dofs found at ({x},{y},{z}), expected 1. Try adjusting the tolerance"
-            )
-
-        return dofs_toappend * 3.0 + np.arange(3, dtype=np.float64)
 
     @abstractmethod
     def apply_to_forces(self, f_int, u):
@@ -85,17 +69,26 @@ class ElasticTrussRebar(RebarInterface):
     Equations from http://what-when-how.com/the-finite-element-method/fem-for-trusses-finite-element-method-part-1/
 
     """
-    def __init__(self, concrete_mesh : dfx.mesh.Mesh, rebar_mesh : dfx.mesh.Mesh, function_space : dfx.fem.FunctionSpace, parameters: dict):
+    def __init__(
+        self,
+        concrete_mesh : dfx.mesh.Mesh,
+        rebar_mesh : dfx.mesh.Mesh,
+        function_space : dfx.fem.FunctionSpace,
+        parameters: dict,
+        vertex_map: np.ndarray,
+    ):
         """Initialize rebar class
 
         Args:
             concrete_mesh: The 3D mesh of the concrete structure.
-            rebar_mesh: The line mesh of the steel rebar.
+            rebar_mesh: The line mesh of the steel rebar, built as a submesh
+                of concrete_mesh's edges (see reinforcement.mesh.read_msh).
             function_space: The function space object of the concrete structure.
             parameters: A dictinary containing all needed parameters of the steel. Contains: 'A', 'E', 'rho'.
+            vertex_map: rebar_mesh's vertex map, as returned by read_msh.
 
         """
-        super().__init__(concrete_mesh, rebar_mesh, function_space, parameters)
+        super().__init__(concrete_mesh, rebar_mesh, function_space, parameters, vertex_map)
 
     def apply_to_diagonal_mass(self, M : PETSc.Vec):
         """

--- a/src/reinforcement/rebar.py
+++ b/src/reinforcement/rebar.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
+
 import dolfinx as dfx
 import numpy as np
 from petsc4py import PETSc
-import sys
 
 
 class RebarInterface(ABC):
@@ -32,7 +32,10 @@ class RebarInterface(ABC):
         self.rebar_mesh.topology.create_connectivity(fdim, 0)
         num_lines_local = self.rebar_mesh.topology.index_map(fdim).size_local
         geometry_entities = dfx.cpp.mesh.entities_to_geometry(
-            self.rebar_mesh, fdim, np.arange(num_lines_local, dtype=np.int32), False
+            self.rebar_mesh._cpp_object,
+            fdim,
+            np.arange(num_lines_local, dtype=np.int32),
+            False,
         )
         dofs = []
         for line in geometry_entities:

--- a/src/reinforcement/rebar.py
+++ b/src/reinforcement/rebar.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 
 import dolfinx as dfx
+import dolfinx.fem.petsc
 import numpy as np
+import ufl
 from petsc4py import PETSc
 
 from .maps import build_vertex_subspace_map
@@ -9,7 +11,8 @@ from .maps import build_vertex_subspace_map
 
 class RebarInterface(ABC):
     """
-    An interface for trusses. Contains methods to assign dofs.
+    An interface for trusses. Builds the rebar function space and the dof
+    map between the rebar submesh and the concrete mesh.
     """
     def __init__(
         self,
@@ -34,25 +37,14 @@ class RebarInterface(ABC):
         self.rebar_mesh = rebar_mesh
         self.function_space = function_space
         self.parameters = parameters
-        self.dof_array = np.array([], dtype=np.int32)
-        self._assign_dofs(vertex_map)
 
-    def _assign_dofs(self, vertex_map: np.ndarray):
-        rebar_function_space = dfx.fem.functionspace(self.rebar_mesh, ("Lagrange", 1, (3,)))
-        space_map = build_vertex_subspace_map(vertex_map, self.function_space, rebar_function_space)
-
-        fdim = self.rebar_mesh.topology.dim
-        self.rebar_mesh.topology.create_connectivity(fdim, 0)
-        cell_to_vertex = self.rebar_mesh.topology.connectivity(fdim, 0)
-        num_lines_local = self.rebar_mesh.topology.index_map(fdim).size_local
-
-        block_size = self.function_space.dofmap.index_map_bs
-        dofs = []
-        for cell in range(num_lines_local):
-            for rebar_vertex in cell_to_vertex.links(cell):
-                concrete_dof = space_map.parent[rebar_vertex]
-                dofs.extend(block_size * concrete_dof + np.arange(block_size))
-        self.dof_array = np.array(dofs, dtype=np.int32).reshape(-1, 3)
+        self.rebar_function_space = dfx.fem.functionspace(rebar_mesh, ("Lagrange", 1, (3,)))
+        self.space_map = build_vertex_subspace_map(
+            vertex_map, function_space, self.rebar_function_space
+        )
+        self.parent_dofs = _block_expand_to_rebar_dof_order(
+            self.space_map, function_space.dofmap.index_map_bs
+        )
 
     @abstractmethod
     def apply_to_forces(self, f_int, u):
@@ -63,10 +55,37 @@ class RebarInterface(ABC):
         pass
 
 
+def _block_expand_to_rebar_dof_order(space_map, block_size: int) -> np.ndarray:
+    """
+    Build the array of concrete (blocked) dof indices corresponding, in
+    order, to every blocked dof of the rebar function space -- i.e. entry k
+    is the concrete dof that rebar dof k should be added into.
+
+    space_map.sub[vertex] gives the rebar dof for a given rebar_mesh vertex,
+    so its inverse gives, for each rebar dof, the vertex it belongs to; from
+    there space_map.parent gives the corresponding concrete dof.
+    """
+    num_dofs = len(space_map.sub)
+    vertex_of_rebar_dof = np.empty(num_dofs, dtype=np.int32)
+    vertex_of_rebar_dof[space_map.sub] = np.arange(num_dofs, dtype=np.int32)
+    parent_dof_of_rebar_dof = space_map.parent[vertex_of_rebar_dof]
+
+    return (
+        block_size * parent_dof_of_rebar_dof[:, None] + np.arange(block_size)[None, :]
+    ).ravel().astype(np.int32)
+
+
 class ElasticTrussRebar(RebarInterface):
     """
     This class can insert purely elastic rebar stiffnesses into the concrete matrix and the internal forces vector.
-    Equations from http://what-when-how.com/the-finite-element-method/fem-for-trusses-finite-element-method-part-1/
+
+    The truss's axial strain/stress are expressed as a UFL weak form on the
+    rebar submesh (a 1D mesh embedded in 3D): the axial strain is the
+    directional derivative of the displacement along the cell's own tangent
+    direction, obtained from the mesh's Jacobian. This is evaluated (and its
+    stiffness assembled) on the small rebar-local function space, then
+    scattered into the caller's global concrete matrix/vector via the dof
+    map from RebarInterface.
 
     """
     def __init__(
@@ -90,93 +109,90 @@ class ElasticTrussRebar(RebarInterface):
         """
         super().__init__(concrete_mesh, rebar_mesh, function_space, parameters, vertex_map)
 
+        V = self.rebar_function_space
+        u_ = ufl.TrialFunction(V)
+        v = ufl.TestFunction(V)
+        # explicit domain: a zero coefficient (e.g. rho defaulting to 0)
+        # collapses the integrand to a symbolic zero, which would otherwise
+        # leave ufl.dx unable to infer the integration domain from it.
+        dx = ufl.Measure("dx", domain=rebar_mesh)
+
+        tangent = ufl.Jacobian(rebar_mesh)[:, 0]
+        tangent = tangent / ufl.sqrt(ufl.dot(tangent, tangent))
+
+        def axial_strain(w):
+            return ufl.dot(tangent, ufl.dot(ufl.grad(w), tangent))
+
+        E = parameters["E"]
+        A = parameters["A"]
+
+        self._u_concrete = dfx.fem.Function(function_space)
+        self._u_rebar = dfx.fem.Function(V)
+
+        self._stiffness_form = dfx.fem.form(E * A * axial_strain(u_) * axial_strain(v) * dx)
+        self._force_form = dfx.fem.form(
+            E * A * axial_strain(self._u_rebar) * axial_strain(v) * dx
+        )
+        self._ones = dfx.fem.Constant(rebar_mesh, PETSc.ScalarType((1.0, 1.0, 1.0)))
+        self._lumped_mass_form = dfx.fem.form(
+            parameters.get("rho", 0.0) * A * ufl.inner(self._ones, v) * dx
+        )
+
     def apply_to_diagonal_mass(self, M : PETSc.Vec):
         """
         Adds nodal masses to a diagonal mass matrix.
-        
+
         Args:
-            M: The diagonal from of the mass matrix as a PETSc vector 
+            M: The diagonal from of the mass matrix as a PETSc vector
 
         """
-        points = self.function_space.tabulate_dof_coordinates().flatten()
-        diagonal_mass_1d = np.array([[1.0, 0.0], [0.0, 1.0]])
-        T = np.zeros((2, 6))
-        for dofs in self.dof_array.reshape(-1, 6):
-            delta_x = points[dofs[3:]] - points[dofs[:3]]
-            l_axial = np.linalg.norm(delta_x, 2)
-            matrix_entries = delta_x / l_axial
-
-            T[0, :3] = matrix_entries
-            T[1, 3:] = matrix_entries
-
-            mass_local = np.diag(
-                T.T
-                @ (
-                    self.parameters["rho"]
-                    * self.parameters["A"]
-                    * l_axial
-                    * diagonal_mass_1d
-                )
-                @ T
-            )
-
-            M.setValues(dofs, mass_local, addv=PETSc.InsertMode.ADD)
-            M.assemble()
+        # row-sum ("HRZ") lumping: for a partition-of-unity basis, the row
+        # sum of the consistent mass matrix equals inner(1, v) integrated
+        # against the same weighting, avoiding an explicit matrix assembly.
+        m_local = dfx.fem.petsc.assemble_vector(self._lumped_mass_form)
+        M.setValues(self.parent_dofs, m_local.array, addv=PETSc.InsertMode.ADD)
+        M.assemble()
 
     def apply_to_stiffness(self, K : PETSc.Mat, u : PETSc.Vec):
         """
         Adds truss stiffness to global stiffness matrix,
-        
+
         Args:
             K: The global stiffness matrix.
             u: The global displacements.
         """
-        points = self.function_space.tabulate_dof_coordinates().flatten()
-        K_1d = np.array([[1.0, -1.0], [-1.0, 1.0]])
-        T = np.zeros((2, 6))
-        for dofs in self.dof_array.reshape(-1, 6):
-            delta_x = points[dofs[3:]] - points[dofs[:3]]
-            l_axial = np.linalg.norm(delta_x, 2)
+        K_local = dfx.fem.petsc.assemble_matrix(self._stiffness_form)
+        K_local.assemble()
 
-            matrix_entries = delta_x / l_axial
-            T[0, :3] = matrix_entries
-            T[1, 3:] = matrix_entries
-            AEL = self.parameters["A"] * self.parameters["E"] / l_axial
-            K_local = T.T @ (AEL * K_1d) @ T
-
-            K.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
-            K.setValues(dofs, dofs, K_local.flat, addv=PETSc.InsertMode.ADD)
-            K.assemble()
+        # scatter only the local matrix's actual (sparse) nonzero structure:
+        # densifying and inserting the full block would submit mostly
+        # explicit zeros (rebar dofs are only weakly connected through a
+        # handful of neighbouring segments), which bloats the global
+        # matrix's sparsity pattern and makes the solve far more expensive.
+        K.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
+        num_local_rows = K_local.getSize()[0]
+        for row in range(num_local_rows):
+            cols, vals = K_local.getRow(row)
+            if len(cols) == 0:
+                continue
+            K.setValues(
+                [self.parent_dofs[row]], self.parent_dofs[cols], vals, addv=PETSc.InsertMode.ADD
+            )
+        K.assemble()
 
     def apply_to_forces(self, f_int : PETSc.Vec, u : PETSc.Vec, sign : float = 1.0):
         """
         Adds truss nodal internal forces to global forces vector.
-        
+
         Args:
             f_int: The global forces vector.
             u: The global displacements.
             sign: Sign of the added values.
         """
         assert sign in [1.0, -1.0]
-        points = self.function_space.tabulate_dof_coordinates().flatten()
-        f_1d = np.array([-1.0, 1.0])
-        T = np.zeros((2, 6))
-        for dofs in self.dof_array.reshape(-1, 6):
-            delta_x = points[dofs[3:]] - points[dofs[:3]]
-            delta_u = u.array[dofs[3:]] - u.array[dofs[:3]]
-            l_axial = np.linalg.norm(delta_x, 2)
-            matrix_entries = delta_x / l_axial
+        self._u_concrete.x.array[:] = u.array
+        self.space_map.map_to_sub(self._u_concrete, self._u_rebar)
 
-            u_axial = np.inner(matrix_entries, delta_u)
-
-            eps_axial = u_axial / l_axial
-
-            T[0, :3] = matrix_entries
-            T[1, 3:] = matrix_entries
-
-            sigma_axial = self.parameters["E"] * eps_axial
-
-            f_local = sign * T.T @ (self.parameters["A"] * sigma_axial * f_1d)
-
-            f_int.setValues(dofs, f_local, addv=PETSc.InsertMode.ADD)
-            f_int.assemble()
+        f_local = dfx.fem.petsc.assemble_vector(self._force_form)
+        f_int.setValues(self.parent_dofs, sign * f_local.array, addv=PETSc.InsertMode.ADD)
+        f_int.assemble()

--- a/test/test_bending_analytical.py
+++ b/test/test_bending_analytical.py
@@ -1,6 +1,4 @@
-from reinforcement.mesh import read_msh
-from mpi4py import MPI
-from reinforcement.mesh import create_concrete_slab, read_xdmf
+from reinforcement.mesh import create_concrete_slab, read_msh
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
 import dolfinx.fem.petsc
@@ -70,15 +68,11 @@ def rebar_problem(n):
     create_concrete_slab(
         point1, point2, nx, ny, margin, h, msh_filename, xdmf_filenames, z=[z_rebar]
     )
-    #full_mesh = dfx.io.gmsh.read_from_msh(msh_filename,MPI.COMM_WORLD)
-    #concrete_mesh = full_mesh.mesh
-    #rebar_entities = full_mesh.ridge_tags.indices[full_mesh.ridge_tags.values == 1]
-    #rebar_mesh,_,_,_, = dfx.mesh.create_submesh(concrete_mesh,1, rebar_entities)
-    concrete_mesh, rebar_mesh = read_msh(msh_filename)
+    concrete_mesh, rebar_mesh, vertex_map = read_msh(msh_filename)
 
     P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
-    rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
+    rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel, vertex_map)
 
 
     def eps(v):

--- a/test/test_bending_analytical.py
+++ b/test/test_bending_analytical.py
@@ -1,6 +1,8 @@
 from reinforcement.mesh import create_concrete_slab, read_xdmf
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
+import dolfinx.fem.petsc
+import dolfinx.nls.petsc
 import ufl
 import numpy as np
 from petsc4py import PETSc
@@ -22,7 +24,7 @@ parameters_concrete = {
     "rho": (2.4*ureg.gram/ureg.centimeter**3).to_base_units().magnitude,
     }
 
-class NonlinearReinforcementProblem(dfx.fem.petsc.NonlinearProblem):
+class NonlinearReinforcementProblem(dfx.fem.petsc.NewtonSolverNonlinearProblem):
     """
     This class demonstrates how the reinforcement could be used in a nonlinear problem.
     """
@@ -69,7 +71,7 @@ def rebar_problem(n):
 
     concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
 
-    P1 = dfx.fem.VectorFunctionSpace(concrete_mesh, ("CG", 1))
+    P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
     rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
 
@@ -114,7 +116,7 @@ def rebar_problem(n):
     ds = ufl.Measure("ds", domain=concrete_mesh, subdomain_data=facet_tag)
     with dfx.io.XDMFFile(concrete_mesh.comm, "facet_tags.xdmf", "w") as xdmf:
         xdmf.write_mesh(concrete_mesh)
-        xdmf.write_meshtags(facet_tag)
+        xdmf.write_meshtags(facet_tag, concrete_mesh.geometry)
 
 
     external_force_form = - pressure * ufl.dot(ufl.FacetNormal(concrete_mesh), v_) * ds(42)
@@ -136,7 +138,7 @@ class DisplacementAtDofSensor:
         self.x = u.function_space.mesh.geometry.x[nodes]
     
     def __call__(self):
-        return self.u.vector.array[self.dofs]
+        return self.u.x.array[self.dofs]
 
 def test_rebar():
     for i in range(2,11):

--- a/test/test_bending_analytical.py
+++ b/test/test_bending_analytical.py
@@ -1,3 +1,5 @@
+from reinforcement.mesh import read_msh
+from mpi4py import MPI
 from reinforcement.mesh import create_concrete_slab, read_xdmf
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
@@ -68,8 +70,11 @@ def rebar_problem(n):
     create_concrete_slab(
         point1, point2, nx, ny, margin, h, msh_filename, xdmf_filenames, z=[z_rebar]
     )
-
-    concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
+    #full_mesh = dfx.io.gmsh.read_from_msh(msh_filename,MPI.COMM_WORLD)
+    #concrete_mesh = full_mesh.mesh
+    #rebar_entities = full_mesh.ridge_tags.indices[full_mesh.ridge_tags.values == 1]
+    #rebar_mesh,_,_,_, = dfx.mesh.create_submesh(concrete_mesh,1, rebar_entities)
+    concrete_mesh, rebar_mesh = read_msh(msh_filename)
 
     P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 

--- a/test/test_internal_forces.py
+++ b/test/test_internal_forces.py
@@ -1,6 +1,7 @@
 from reinforcement.mesh import create_concrete_slab, read_xdmf
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
+import dolfinx.fem.petsc
 import numpy as np
 import ufl
 from pint import UnitRegistry
@@ -39,7 +40,7 @@ create_concrete_slab(
 
 concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
 
-P1 = dfx.fem.VectorFunctionSpace(concrete_mesh, ("CG", 1))
+P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
 rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
 
@@ -50,13 +51,13 @@ v_ = ufl.TestFunction(P1)
 a = ufl.inner(u_,v_) * ufl.dx
 
 A = dfx.fem.petsc.create_matrix(dfx.fem.form(a))
-f_int = b.vector
+f_int = b.x.petsc_vec
 
-#u.vector.array[:] = np.random.random(u.vector.array.size)
+#u.x.array[:] = np.random.random(u.x.array.size)
 u.interpolate(lambda x:(0.005*x[0], -0.005*x[1], 0.*x[2]))
 
-rebar.apply_to_stiffness(A, u.vector)
-rebar.apply_to_forces(f_int, u.vector)
+rebar.apply_to_stiffness(A, u.x.petsc_vec)
+rebar.apply_to_forces(f_int, u.x.petsc_vec)
 
 def petsc2array(v):
     s=v.getValues(range(0, v.getSize()[0]), range(0,  v.getSize()[1]))
@@ -66,6 +67,6 @@ A_dense = A.convert("dense")
 A_arr = petsc2array(A_dense)
 
 def test_f_int_equals_Ku():
-    Au = A_arr@u.vector.array
+    Au = A_arr@u.x.array
     f_arr = f_int.array
     assert np.linalg.norm(Au-f_arr)/np.linalg.norm(f_arr) < 1e-12

--- a/test/test_internal_forces.py
+++ b/test/test_internal_forces.py
@@ -1,4 +1,4 @@
-from reinforcement.mesh import create_concrete_slab, read_xdmf
+from reinforcement.mesh import create_concrete_slab, read_msh
 from reinforcement.rebar import ElasticTrussRebar
 import dolfinx as dfx
 import dolfinx.fem.petsc
@@ -38,11 +38,11 @@ create_concrete_slab(
     point1, point2, nx, ny, margin, h, msh_filename, xdmf_filenames, z=[z_rebar]
 )
 
-concrete_mesh, rebar_mesh = read_xdmf(xdmf_filenames)
+concrete_mesh, rebar_mesh, vertex_map = read_msh(msh_filename)
 
 P1 = dfx.fem.functionspace(concrete_mesh, ("CG", 1, (concrete_mesh.geometry.dim,)))
 
-rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel)
+rebar = ElasticTrussRebar(concrete_mesh, rebar_mesh, P1, parameters_steel, vertex_map)
 
 u = dfx.fem.Function(P1)
 b = dfx.fem.Function(P1)


### PR DESCRIPTION
I hereby declare that I will confirm what claude has done here at a later point...
The new structure with the submesh and mapping between subspace and global space makes this structurally very similar to fenics-constitutive

This adds:
* Support for dolfinx 0.11.0
* Refactoring of mesh reading: Now the rebar-mesh is created directly from the 3d mesh using mesh-tags and `create_submesh` instead of generating two seperate meshes. This has the advantage that with MPI support, corresponding rebar and concrete elements live on the same mpi rank.
* Manual assembly of stiffness and forces done with ufl forms on the rebar mesh
* Mapping of dofs directly through the EntityMap from the submesh instead of "closeness" condition from before